### PR TITLE
[FIX] account: None type of search panel

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import frozendict, formatLang, format_date, float_is_zero
+from odoo.tools import frozendict, formatLang, format_date, float_is_zero, Query
 from odoo.tools.sql import create_index
 from odoo.addons.web.controllers.utils import clean_action
 
@@ -1541,6 +1541,11 @@ class AccountMoveLine(models.Model):
 
         # Override in order to not read the complete move line table and use the index instead
         query = self._search(domain, limit=1)
+
+        # if domain is logically equivalent to false
+        if not isinstance(query, Query):
+            return {}
+
         query.order = None
         query.add_where('account.id = account_move_line.account_id')
         query_str, query_param = query.select()


### PR DESCRIPTION
See: 26dd1d9627cdd04e12c3187f0f53c0e11892a345

## Description of the issue/feature this PR addresses:

- Step 1: Create a button, and return the action with custom domain, for example:
```
        return {
            "name": _("Reconciliations"),
            "view_mode": "tree,form",
            "res_model": "account.move.line",
            "type": "ir.actions.act_window",
            "context": context,
            "target": "current",
            "domain": [
                ("id", "in", []),
            ],
        }
```

- Step 2: Click the button

## Current behavior before PR:

- Using a custom domain, such as: `[('id', 'in', [])]`, will raise the issue
```
...
    query.order = None
AttributeError: 'list' object has no attribute 'order'
```

## Desired behavior after PR is merged:

This fixes the error when returning an action of the model `account.move.line`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
